### PR TITLE
accelerate kmeans

### DIFF
--- a/python/pudding/clustering/kmeans.py
+++ b/python/pudding/clustering/kmeans.py
@@ -72,6 +72,13 @@ class KMeans(_BaseModel):
         np_X = X.astype(np.float32)
         n_samples, n_features = np_X.shape
 
+        # Compute a dataset dependent tolerance
+        _tol = 0
+        if self.tol == 0:
+            _tol = 0
+        else:
+            _tol = np.mean(np.var(np_X, axis=0)) * self.tol
+
         # Prepare the initial centers
         if initial_centers is None:
             np_initial_centers = np.array(np_X[np.random.choice(n_samples, self.n_clusters, replace=False)]).astype(np.float32)
@@ -102,7 +109,7 @@ class KMeans(_BaseModel):
 
         # Call the function
         c_n_iter = ctypes.c_int(n_iter)
-        c_kmeans(np_X, np_initial_centers, n_samples, n_features, self.n_clusters, self.max_iter, self.tol, self.cuda_enabled, np_centers, np_membership, ctypes.byref(c_n_iter))
+        c_kmeans(np_X, np_initial_centers, n_samples, n_features, self.n_clusters, self.max_iter, _tol, self.cuda_enabled, np_centers, np_membership, ctypes.byref(c_n_iter))
         n_iter = c_n_iter.value
 
         self.centers = np_centers


### PR DESCRIPTION
Previous implementation of KMeans is slow and unstable. This PR tries to fix that by making the following modifications:
1. The old ```determineMembershipKernel``` is replaced by a much faster ```wrapperComputePairwiseEuclideanDistanceKerenl```, together with a ```wrapperMatrixArgMaxRowKernel```.
2. The old ```updateCentersKernel``` is replaced by a mask generation kernel together with a cublas matrix multiplication function in order to compute the new cluster center.
3. In the Python binding, the tolerance of the KMeans algorithm is adjusted according to the variance of the dataset, which is the same as scikit-learn.

These modifications have the advantage of reusing existing general kernel functions instead of writing new kernel functions for each individual algorithms. Also, it fixes the bug of potentially allocating a shared memory that is too large to fit if the number of cluster centers is too big or the feature dimension is too high. Now the implementation should work properly in most cases.